### PR TITLE
Potential fix for code scanning alert no. 6: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/bundles/com.tlcsdm.eclipse.rcp.example.python3.win32.x86_64/src/com/tlcsdm/eclipse/rcp/example/python3/Activator.java
+++ b/bundles/com.tlcsdm.eclipse.rcp.example.python3.win32.x86_64/src/com/tlcsdm/eclipse/rcp/example/python3/Activator.java
@@ -88,6 +88,7 @@ public class Activator extends AbstractUIPlugin {
         Path target = installDir.resolve("runtimes/python");
         // 确保目标目录存在，即使 runtimes 或 python 文件夹不存在
         Files.createDirectories(target);
+        Path normalizedTarget = target.toAbsolutePath().normalize();
 
         // 2. 检查是否已经安装过
         Path pythonExe = target.resolve("python.exe");
@@ -103,7 +104,10 @@ public class Activator extends AbstractUIPlugin {
 
                 ZipEntry entry;
                 while ((entry = zis.getNextEntry()) != null) {
-                    Path filePath = target.resolve(entry.getName());
+                    Path filePath = normalizedTarget.resolve(entry.getName()).normalize();
+                    if (!filePath.startsWith(normalizedTarget)) {
+                        throw new IOException("Bad zip entry: " + entry.getName());
+                    }
                     if (entry.isDirectory()) {
                         Files.createDirectories(filePath);
                     } else {


### PR DESCRIPTION
Potential fix for [https://github.com/tlcsdm/eclipse-rcp-example/security/code-scanning/6](https://github.com/tlcsdm/eclipse-rcp-example/security/code-scanning/6)

To fix Zip Slip safely, normalize and validate each computed output path before any file operation. The best approach here is:

1. Build a normalized base extraction directory (`target.toAbsolutePath().normalize()`).
2. For each ZIP entry, resolve and normalize the output path:
   - `resolvedPath = targetPath.resolve(entry.getName()).normalize()`
3. Reject entries whose normalized path does not start with the normalized target base:
   - `if (!resolvedPath.startsWith(targetPath)) throw new IOException(...)`
4. Use the validated `resolvedPath` for directory creation and file copy.

This single validation point addresses all three alert variants (directory creation, parent directory creation, and file copy).  
Edits are only needed in `bundles/com.tlcsdm.eclipse.rcp.example.python3.win32.x86_64/src/com/tlcsdm/eclipse/rcp/example/python3/Activator.java`, within `install()` around the ZIP extraction loop. No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
